### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/lib/src/engine/transport/vmv/xhr_transport.dart
+++ b/lib/src/engine/transport/vmv/xhr_transport.dart
@@ -293,7 +293,7 @@ class Request extends EventEmitter {
       if (contentType == 'application/octet-stream') {
         data = resp;
       } else {
-        data = resp.transform(utf8.decoder).join();
+        data = utf8.decoder.bind(resp).join();
       }
     } catch (e) {
       this.onError(e);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: socket_io_common_client
 description: Dartlang port of socket.io-client, Support VM(Flutter, cmd, server) and web front-end
-version: 0.10.0
+version: 0.10.0+1
 author: bixiaopeng <bixiaopeng2007@gmail.com>
 homepage: https://github.com/moshoujingli/socket.io-client-dart
 


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900